### PR TITLE
Release WP Job Manager 1.42.0

### DIFF
--- a/includes/helper/class-wp-job-manager-helper-api.php
+++ b/includes/helper/class-wp-job-manager-helper-api.php
@@ -41,13 +41,13 @@ class WP_Job_Manager_Helper_API {
 	/**
 	 * Checks if there is an update for the plugin using the WPJobManager.com API.
 	 *
-	 * @deprecated $$next-version$$ Use WP_Job_Manager_Helper_API::bulk_update_check() instead.
+	 * @deprecated 1.42.0 Use WP_Job_Manager_Helper_API::bulk_update_check() instead.
 	 *
 	 * @param array $args The arguments to pass to the endpoint.
 	 * @return array|false The response, or false if the request failed.
 	 */
 	public function plugin_update_check( $args ) {
-		_deprecated_file( __METHOD__, '$$next-version$$', 'WP_Job_Manager_Helper_API::bulk_update_check' );
+		_deprecated_file( __METHOD__, '1.42.0', 'WP_Job_Manager_Helper_API::bulk_update_check' );
 
 		return false;
 	}

--- a/includes/helper/class-wp-job-manager-helper.php
+++ b/includes/helper/class-wp-job-manager-helper.php
@@ -103,15 +103,15 @@ class WP_Job_Manager_Helper {
 		$deprecated_methods = [
 			'has_licenced_products' => [
 				'replacement' => [ $this, 'has_licensed_products' ],
-				'version'     => '$$next-version$$',
+				'version'     => '1.42.0',
 			],
 			'get_plugin_licence'    => [
 				'replacement' => [ $this, 'get_plugin_license' ],
-				'version'     => '$$next-version$$',
+				'version'     => '1.42.0',
 			],
 			'licence_output'        => [
 				'replacement' => [ $this, 'license_output' ],
-				'version'     => '$$next-version$$',
+				'version'     => '1.42.0',
 			],
 			'licence_error_notices' => [
 				'replacement' => [ $this, 'maybe_add_license_error_notices' ],
@@ -119,11 +119,11 @@ class WP_Job_Manager_Helper {
 			],
 			'activate_licence'      => [
 				'replacement' => [ $this, 'activate_license' ],
-				'version'     => '$$next-version$$',
+				'version'     => '1.42.0',
 			],
 			'deactivate_licence'    => [
 				'replacement' => [ $this, 'deactivate_license' ],
-				'version'     => '$$next-version$$',
+				'version'     => '1.42.0',
 			],
 		];
 
@@ -590,7 +590,7 @@ class WP_Job_Manager_Helper {
 	/**
 	 * Returns list of installed WPJM plugins with managed licenses indexed by product ID.
 	 *
-	 * @since $$next-version$$ Added required $keyed_by_filename parameter.
+	 * @since 1.42.0 Added required $keyed_by_filename parameter.
 	 *
 	 * @param bool $active_only       Only return active plugins.
 	 * @param bool $keyed_by_filename Key by plugin filename instead of product slug. Allows for multiple plugins with the same product slug.
@@ -602,7 +602,7 @@ class WP_Job_Manager_Helper {
 		}
 
 		if ( null === $keyed_by_filename ) {
-			_doing_it_wrong( __METHOD__, 'The $keyed_by_filename parameter is required.', '$$next-version$$' );
+			_doing_it_wrong( __METHOD__, 'The $keyed_by_filename parameter is required.', '1.42.0' );
 			$keyed_by_filename = false;
 		}
 
@@ -613,7 +613,7 @@ class WP_Job_Manager_Helper {
 		 * Clear the plugin cache on first request for installed WPJM add-on plugins when no plugins found.
 		 *
 		 * @since 1.29.1
-		 * @since $$next-version$$ Only do this when we don't see WP Job Manager in the plugins list.
+		 * @since 1.42.0 Only do this when we don't see WP Job Manager in the plugins list.
 		 *
 		 * @param bool $clear_plugin_cache True if we should clear the plugin cache.
 		 */

--- a/languages/wp-job-manager.pot
+++ b/languages/wp-job-manager.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Job Manager 1.41.0\n"
+"Project-Id-Version: WP Job Manager 1.42.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-job-manager/\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-07-04T10:38:09+00:00\n"
+"POT-Creation-Date: 2023-09-11T19:18:50+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0\n"
+"X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: wp-job-manager\n"
 
 #. Plugin Name of the plugin
@@ -234,7 +234,6 @@ msgstr ""
 msgid "%1$s updated. <a href=\"%2$s\">View</a>"
 msgstr ""
 
-#. translators: %1$s is the singular name of the job listing post type; %2$s is the URL to view the listing.
 #: includes/admin/class-wp-job-manager-cpt.php:460
 msgid "Custom field updated."
 msgstr ""
@@ -352,7 +351,6 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/admin/class-wp-job-manager-cpt.php:652
 #: includes/class-wp-job-manager-post-types.php:340
 #: includes/class-wp-job-manager-shortcodes.php:450
@@ -738,55 +736,55 @@ msgid "Sets all new submissions to \"pending.\" They will not appear on your sit
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:358
-msgid "Renewal Days"
-msgstr ""
-
-#: includes/admin/class-wp-job-manager-settings.php:359
-msgid "Sets the number of days before expiration, that users can renew the listing. Use 0 to disable renewals."
-msgstr ""
-
-#: includes/admin/class-wp-job-manager-settings.php:366
 msgid "Allow Pending Edits"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:367
+#: includes/admin/class-wp-job-manager-settings.php:359
 msgid "Allow editing of pending listings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:368
+#: includes/admin/class-wp-job-manager-settings.php:360
 msgid "Users can continue to edit pending listings until they are approved by an admin."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:375
+#: includes/admin/class-wp-job-manager-settings.php:367
 msgid "Allow Published Edits"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:376
+#: includes/admin/class-wp-job-manager-settings.php:368
 msgid "Allow editing of published listings"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:377
+#: includes/admin/class-wp-job-manager-settings.php:369
 msgid "Choose whether published job listings can be edited and if edits require admin approval. When moderation is required, the original job listings will be unpublished while edits await admin approval."
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:380
+#: includes/admin/class-wp-job-manager-settings.php:372
 msgid "Users cannot edit"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:381
+#: includes/admin/class-wp-job-manager-settings.php:373
 msgid "Users can edit without admin approval"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:382
+#: includes/admin/class-wp-job-manager-settings.php:374
 msgid "Users can edit, but edits require admin approval"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:389
+#: includes/admin/class-wp-job-manager-settings.php:381
 msgid "Listing Duration"
 msgstr ""
 
-#: includes/admin/class-wp-job-manager-settings.php:390
+#: includes/admin/class-wp-job-manager-settings.php:382
 msgid "Listings will display for the set number of days, then expire. Leave this field blank if you don't want listings to have an expiration date."
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-settings.php:388
+msgid "Renewal Window"
+msgstr ""
+
+#: includes/admin/class-wp-job-manager-settings.php:389
+msgid "Sets the number of days before expiration where users are given the option to renew their listings. For example, entering \"7\" will allow users to renew their listing one week before expiration. Entering \"0\" will disable renewals entirely."
 msgstr ""
 
 #: includes/admin/class-wp-job-manager-settings.php:396
@@ -1222,7 +1220,6 @@ msgstr[1] ""
 msgid "You must be logged in to upload files using this method."
 msgstr ""
 
-#. translators: Placeholder %s is the singular label of the job listing post type.
 #: includes/class-wp-job-manager-data-exporter.php:51
 #: includes/class-wp-job-manager-post-types.php:357
 msgid "Company Logo"
@@ -1435,7 +1432,6 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#. translators: Placeholder %s is the plural label of the job listing post type.
 #: includes/class-wp-job-manager-post-types.php:337
 msgid "Add New"
 msgstr ""
@@ -1649,7 +1645,6 @@ msgstr ""
 msgid "Missing submission page."
 msgstr ""
 
-#. translators: Placeholder %s is the plural label for the job listing post type.
 #: includes/class-wp-job-manager-shortcodes.php:401
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:36
 #: includes/widgets/class-wp-job-manager-widget-featured-jobs.php:52
@@ -1972,61 +1967,84 @@ msgstr ""
 msgid "Renew Listing &rarr;"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:334
+#: includes/helper/class-wp-job-manager-helper.php:355
+msgid "your WP Job Manager plugin"
+msgstr ""
+
+#. translators: First placeholder is the plugin name, second placeholder is the My Account URL.
+#: includes/helper/class-wp-job-manager-helper.php:381
+msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> is not activated on this website and has been removed. Manage your activations on your <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">My Account page</a>."
+msgstr ""
+
+#. translators: First placeholder is the plugin name; second placeholder is the URL to purchase the plugin.
+#: includes/helper/class-wp-job-manager-helper.php:386
+msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> is not valid and has been removed. <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">Purchase a new license</a> to receive updates and support."
+msgstr ""
+
+#. translators: First placeholder is the plugin name, second placeholder is the My Account URL.
+#: includes/helper/class-wp-job-manager-helper.php:391
+msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> has expired. You must <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">renew your license</a> to receive updates and support."
+msgstr ""
+
+#. translators: First placeholder is the plugin name, second placeholder is the My Account URL.
+#: includes/helper/class-wp-job-manager-helper.php:394
+msgid "<strong>Error:</strong> The license for <strong>%1$s</strong> is expiring soon. Please <a href=\"%2$s\" rel=\"noopener noreferrer\" target=\"_blank\">renew your license</a> to continue receiving updates and support."
+msgstr ""
+
+#: includes/helper/class-wp-job-manager-helper.php:476
 msgid "Manage License (Requires Attention)"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:337
-#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:243
+#: includes/helper/class-wp-job-manager-helper.php:479
 msgid "Manage License"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:340
+#: includes/helper/class-wp-job-manager-helper.php:482
 #: includes/helper/views/html-licenses.php:44
 #: includes/helper/views/html-licenses.php:170
-#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:259
+#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:155
 msgid "Activate License"
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:641
+#: includes/helper/class-wp-job-manager-helper.php:786
 msgid "Please enter a valid license key in order to activate this plugin's license."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:671
+#: includes/helper/class-wp-job-manager-helper.php:816
 msgid "Please enter a valid license key in order to activate the licenses of the plugins."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:698
+#: includes/helper/class-wp-job-manager-helper.php:843
 msgid "There was an error activating your license key. Please try again later."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:752
+#: includes/helper/class-wp-job-manager-helper.php:898
 msgid "license is not active."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:768
+#: includes/helper/class-wp-job-manager-helper.php:917
 msgid "Plugin license has been deactivated."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:889
+#: includes/helper/class-wp-job-manager-helper.php:1012
 msgid "Connection failed to the License Key API server - possible server issue."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:898
+#: includes/helper/class-wp-job-manager-helper.php:1021
 msgid "Plugin license has been activated."
 msgstr ""
 
-#: includes/helper/class-wp-job-manager-helper.php:902
+#: includes/helper/class-wp-job-manager-helper.php:1025
 msgid "An unknown error occurred while attempting to activate the license"
 msgstr ""
 
 #. translators: %1$s is the URL to the license key page, %2$s is the plugin name.
-#: includes/helper/class-wp-job-manager-helper.php:936
+#: includes/helper/class-wp-job-manager-helper.php:1063
 msgid "<a href=\"%1$s\">Please enter your license key</a> to get updates for \"%2$s\"."
 msgstr ""
 
 #. translators: %1$s is the plugin name, %2$s is the URL to the license key page.
-#: includes/helper/class-wp-job-manager-helper.php:968
+#: includes/helper/class-wp-job-manager-helper.php:1095
 msgid "There is a problem with the license for \"%1$s\". Please <a href=\"%2$s\">manage the license</a> to check for a solution and continue receiving updates."
 msgstr ""
 
@@ -2452,7 +2470,6 @@ msgstr ""
 msgid "%s submitted successfully. Your listing will be visible once approved."
 msgstr ""
 
-#. translators: %1$s is the URL to view the listing; %2$s is
 #: templates/job-submitted.php:61
 msgid "  <a href=\"%1$s\"> View your %2$s</a>"
 msgstr ""
@@ -2464,6 +2481,10 @@ msgstr ""
 #. translators: %1$s is the job listing post type name.
 #: templates/job-submitted.php:92
 msgid "%1$s submitted successfully."
+msgstr ""
+
+#: tests/php/tests/includes/helper/test_class.wp-job-manager-helper.php:122
+msgid "Requires Attention"
 msgstr ""
 
 #: wp-job-manager-functions.php:368

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-job-manager",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-job-manager",
-      "version": "1.41.0",
+      "version": "1.42.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "select2": "4.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-job-manager",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "WP Job Manager",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: job manager, job listing, job board, job management, job lists, job list, 
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 1.41.0
+Stable tag: 1.42.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-job-manager.php
+++ b/wp-job-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Job Manager
  * Plugin URI: https://wpjobmanager.com/
  * Description: Manage job listings from the WordPress admin panel, and allow users to post jobs directly to your site.
- * Version: 1.41.0
+ * Version: 1.42.0
  * Author: Automattic
  * Author URI: https://wpjobmanager.com/
  * Requires at least: 6.0


### PR DESCRIPTION
> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
> 

## WP Job Manager 1.42.0

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
> 

### Release Notes

---  

* Support dynamically added date form fields
* Show/Hide company logo File Upload button (#2569)
* Allow plugins to override renewal values (#2566)
* Fix notice dismiss JS dependency error (#2557)
* Test changelog generation
* Always show search actions (#2454)

---  

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org


